### PR TITLE
Adicionar o Sequelize CLI como dependencia de produção

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pg-hstore": "^2.3.3",
     "prettier": "^2.0.4",
     "sequelize": "^5.21.6",
+    "sequelize-cli": "^5.5.1",
     "swagger-jsdoc": "^4.0.0",
     "swagger-ui-express": "^4.1.4"
   },
@@ -46,8 +47,7 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2",
-    "nodemon": "^2.0.3",
-    "sequelize-cli": "^5.5.1"
+    "nodemon": "^2.0.3"
   },
   "engines": {
     "node": "13.x"


### PR DESCRIPTION
Ocorrência de erro no Heroku devido a falta de instalação do Sequelize CLI